### PR TITLE
refactor(ProviderModelsPicker.tsx): move Popover.Content to Popover.Portal to fix settings modal dropdown rendering

### DIFF
--- a/src/settings/components/ProviderModelsPicker.tsx
+++ b/src/settings/components/ProviderModelsPicker.tsx
@@ -343,81 +343,83 @@ export const ComboBoxComponent: React.FC<ComboBoxComponentProps> = ({
 								</svg>
 							</button>
 						</Popover.Trigger>
-						<Popover.Content
-							side="bottom"
-							align="start"
-							sideOffset={4}
-							className="infio-llm-setting-combobox-dropdown"
-						>
-							<div ref={listRef}>
-								<div className="infio-llm-setting-search-container">
-									<input
-										type="text"
-										className="infio-llm-setting-item-search"
-										placeholder={modelIds.length > 0 ? t("settings.ModelProvider.searchOrEnterModelName") : t("settings.ModelProvider.enterCustomModelName")}
-										value={searchTerm}
-										onChange={(e) => {
-											setSearchTerm(e.target.value);
-											setSelectedIndex(0);
-										}}
-										onKeyDown={(e) => {
-											switch (e.key) {
-												case "ArrowDown":
-													e.preventDefault();
-													setSelectedIndex((prev) =>
-														Math.min(prev + 1, filteredOptions.length - 1)
-													);
-													break;
-												case "ArrowUp":
-													e.preventDefault();
-													setSelectedIndex((prev) => Math.max(prev - 1, 0));
-													break;
-												case "Enter": {
-													e.preventDefault();
-													if (filteredOptions.length > 0) {
-														const selectedOption = filteredOptions[selectedIndex];
-														if (selectedOption) {
-															handleModelSelect(modelProvider, selectedOption.id, selectedOption.isCustom);
+						<Popover.Portal container={document.querySelector('.modal-container')}>
+							<Popover.Content
+								side="bottom"
+								align="start"
+								sideOffset={4}
+								className="infio-llm-setting-combobox-dropdown"
+							>
+								<div ref={listRef}>
+									<div className="infio-llm-setting-search-container">
+										<input
+											type="text"
+											className="infio-llm-setting-item-search"
+											placeholder={modelIds.length > 0 ? t("settings.ModelProvider.searchOrEnterModelName") : t("settings.ModelProvider.enterCustomModelName")}
+											value={searchTerm}
+											onChange={(e) => {
+												setSearchTerm(e.target.value);
+												setSelectedIndex(0);
+											}}
+											onKeyDown={(e) => {
+												switch (e.key) {
+													case "ArrowDown":
+														e.preventDefault();
+														setSelectedIndex((prev) =>
+															Math.min(prev + 1, filteredOptions.length - 1)
+														);
+														break;
+													case "ArrowUp":
+														e.preventDefault();
+														setSelectedIndex((prev) => Math.max(prev - 1, 0));
+														break;
+													case "Enter": {
+														e.preventDefault();
+														if (filteredOptions.length > 0) {
+															const selectedOption = filteredOptions[selectedIndex];
+															if (selectedOption) {
+																handleModelSelect(modelProvider, selectedOption.id, selectedOption.isCustom);
+															}
+														} else if (searchTerm.trim()) {
+															// If no options but there is input content, use the input content directly
+															handleModelSelect(modelProvider, searchTerm.trim(), true);
 														}
-													} else if (searchTerm.trim()) {
-														// If no options but there is input content, use the input content directly
-														handleModelSelect(modelProvider, searchTerm.trim(), true);
-													}
-													setSearchTerm("");
-													setIsOpen(false);
-													break;
-												}
-												case "Escape":
-													e.preventDefault();
-													setIsOpen(false);
-													setSearchTerm("");
-													break;
-											}
-										}}
-									/>
-								</div>
-								{filteredOptions.length > 0 ? (
-									<div className="infio-llm-setting-options-list">
-										{filteredOptions.map((option, index) => (
-											<Popover.Close key={option.id} asChild>
-												<div
-													ref={(el) => (itemRefs.current[index] = el)}
-													onMouseEnter={() => setSelectedIndex(index)}
-													onClick={() => {
-														handleModelSelect(modelProvider, option.id, option.isCustom);
 														setSearchTerm("");
 														setIsOpen(false);
-													}}
-													className={`infio-llm-setting-combobox-option ${index === selectedIndex ? 'is-selected' : ''}`}
-												>
-													<HighlightedText segments={option.html} />
-												</div>
+														break;
+													}
+													case "Escape":
+														e.preventDefault();
+														setIsOpen(false);
+														setSearchTerm("");
+														break;
+												}
+											}}
+										/>
+									</div>
+									{filteredOptions.length > 0 ? (
+										<div className="infio-llm-setting-options-list">
+											{filteredOptions.map((option, index) => (
+												<Popover.Close key={option.id} asChild>													
+													<div
+														ref={(el) => (itemRefs.current[index] = el)}
+														onMouseEnter={() => setSelectedIndex(index)}
+														onClick={() => {
+															handleModelSelect(modelProvider, option.id, option.isCustom);
+															setSearchTerm("");
+															setIsOpen(false);
+														}}
+														className={`infio-llm-setting-combobox-option ${index === selectedIndex ? 'is-selected' : ''}`}
+													>
+														<HighlightedText segments={option.html} />
+													</div>
 											</Popover.Close>
 										))}
-									</div>
-								) : null}
-							</div>
-						</Popover.Content>
+										</div>
+									) : null}
+								</div>
+							</Popover.Content>
+						</Popover.Portal>
 					</Popover.Root>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

- In Obsidian Catalyst v1.9.6, the model selection dropdown in the Settings modal was rendering in the wrong place due to stacking-context issues.
- Moved Popover.Content into a Popover.Portal targeting the .modal-container so the dropdown is rendered outside the modal’s stacking context.
- Ensures the dropdown menu is always visible and interactive, improving the user experience.

## Changes

- Updated ProviderModelsPicker.tsx to wrap Popover.Content in Popover.Portal with container=".modal-container".

## Screenshots

**before**
<img width="1072" height="643" alt="Appearance" src="https://github.com/user-attachments/assets/d384495e-5d63-4697-81f1-22d88c02e6df" />

**after**
<img width="769" height="429" alt="스크린샷 2025-07-25 오후 4 18 28" src="https://github.com/user-attachments/assets/fff35717-4fb3-4160-a9ff-3ce16564d053" />

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have run the test suite (by running `pnpm run test`)
- [x] I have tested the functionality manually
