### PR TITLE
fix: gemini可自定义baseUrl，模型列表自动获取，自定义嵌入模型维度

### DIFF
--- a/src/components/chat-view/chat-input/ModelSelect.tsx
+++ b/src/components/chat-view/chat-input/ModelSelect.tsx
@@ -203,7 +203,7 @@ export function ModelSelect({ modelType = 'chat' }: ModelSelectProps) {
 			setIsLoading(true)
 			try {
 				if (modelType === 'embedding') {
-					const models = GetEmbeddingProviderModelIds(modelProvider)
+					const models = await GetEmbeddingProviderModelIds(modelProvider, settings)
 					setModelIds(models)
 				} else {
 					const models = await GetProviderModelsWithSettings(modelProvider, settings)

--- a/src/core/llm/manager.ts
+++ b/src/core/llm/manager.ts
@@ -79,7 +79,12 @@ class LLMManager implements LLMManagerInterface {
 		)
 		this.openaiProvider = new OpenAIAuthenticatedProvider(settings.openaiProvider.apiKey)
 		this.anthropicProvider = new AnthropicProvider(settings.anthropicProvider.apiKey)
-		this.googleProvider = new GeminiProvider(settings.googleProvider.apiKey)
+		this.googleProvider = new GeminiProvider(
+			settings.googleProvider.apiKey,
+			settings.googleProvider.baseUrl && settings.googleProvider.useCustomUrl ?
+				settings.googleProvider.baseUrl
+				: undefined
+		)
 		this.groqProvider = new GroqProvider(settings.groqProvider.apiKey)
 		this.grokProvider = new OpenAICompatibleProvider(settings.grokProvider.apiKey,
 			settings.grokProvider.baseUrl && settings.grokProvider.useCustomUrl ?
@@ -149,7 +154,6 @@ class LLMManager implements LLMManagerInterface {
 				return await this.googleProvider.generateResponse(
 					model,
 					request,
-					options,
 				)
 			case ApiProvider.Groq:
 				return await this.groqProvider.generateResponse(model, request, options)
@@ -203,7 +207,7 @@ class LLMManager implements LLMManagerInterface {
 					options,
 				)
 			case ApiProvider.Google:
-				return await this.googleProvider.streamResponse(model, request, options)
+				return await this.googleProvider.streamResponse(model, request)
 			case ApiProvider.Groq:
 				return await this.groqProvider.streamResponse(model, request, options)
 			case ApiProvider.Grok:

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -319,6 +319,8 @@ export default {
 				failed: 'Failed',
 				test: 'Test',
 			},
+			embeddingDimensions: 'Embedding Dimensions',
+			embeddingDimensionsDescription: 'Set the dimension size for embedding vectors. Smaller dimensions can save storage space and computational resources, but may reduce semantic search accuracy. Minimum: 1, Default: 768',
 		},
 		
 		// Model Parameters Section

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -320,6 +320,8 @@ export default {
 				failed: '失败',
 				test: '测试',
 			},
+			embeddingDimensions: '嵌入维度',
+			embeddingDimensionsDescription: '设置嵌入向量的维度大小。较小的维度可以节省存储空间和计算资源，但可能会降低语义搜索的精度。最小值：1，默认：768',
 		},
 		
 		// 模型参数部分

--- a/src/settings/components/ModelProviderSettings.tsx
+++ b/src/settings/components/ModelProviderSettings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { t } from '../../lang/helpers';
+
 import InfioPlugin from "../../main";
 import { ApiProvider } from '../../types/llm/model';
 import { InfioSettings } from '../../types/settings';
@@ -10,7 +11,7 @@ import {
 } from '../../utils/api';
 import { getProviderApiUrl } from '../../utils/provider-urls';
 
-import { ApiKeyComponent, CustomUrlComponent } from './FormComponents';
+import { ApiKeyComponent, CustomUrlComponent, TextComponent } from './FormComponents';
 import { ComboBoxComponent } from './ProviderModelsPicker';
 
 type CustomProviderSettingsProps = {
@@ -187,6 +188,24 @@ const CustomProviderSettings: React.FC<CustomProviderSettingsProps> = ({ plugin,
 			[providerKey]: {
 				...providerSettings,
 				baseUrl: value
+			}
+		});
+	};
+
+	// 直接保存嵌入维度设置
+	const updateProviderEmbeddingDimensions = (provider: ApiProvider, value: string) => {
+		const providerKey = getProviderSettingKey(provider);
+		const providerSettings = settings[providerKey];
+		
+		// 将字符串转换为数字，并确保在有效范围内（只保留最小值1的限制）
+		const numValue = parseInt(value, 10);
+		const validValue = isNaN(numValue) ? 768 : Math.max(1, numValue);
+
+		handleSettingsUpdate({
+			...settings,
+			[providerKey]: {
+				...providerSettings,
+				embeddingDimensions: validValue
 			}
 		});
 	};
@@ -549,6 +568,7 @@ const CustomProviderSettings: React.FC<CustomProviderSettingsProps> = ({ plugin,
 						modelId={settings.embeddingModelId}
 						isEmbedding={true}
 						updateModel={updateEmbeddingModelId}
+						onUpdateEmbeddingDimensions={updateProviderEmbeddingDimensions}
 					/>
 				</div>
 			</div>

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -166,6 +166,7 @@ describe('parseSmartCopilotSettings', () => {
 				baseUrl: '',
 				useCustomUrl: false,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			groqProvider: {
 				name: 'Groq',
@@ -194,6 +195,7 @@ describe('parseSmartCopilotSettings', () => {
 				name: 'Ollama',
 				useCustomUrl: true,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			openaiProvider: {
 				name: 'OpenAI',
@@ -208,6 +210,7 @@ describe('parseSmartCopilotSettings', () => {
 				baseUrl: '',
 				useCustomUrl: true,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			openrouterProvider: {
 				name: 'OpenRouter',
@@ -415,6 +418,7 @@ describe('settings migration', () => {
 				baseUrl: '',
 				useCustomUrl: false,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			groqProvider: {
 				name: 'Groq',
@@ -443,6 +447,7 @@ describe('settings migration', () => {
 				name: 'Ollama',
 				useCustomUrl: true,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			openaiProvider: {
 				name: 'OpenAI',
@@ -457,6 +462,7 @@ describe('settings migration', () => {
 				baseUrl: '',
 				useCustomUrl: true,
 				models: [],
+				embeddingDimensions: 768,
 			},
 			openrouterProvider: {
 				name: 'OpenRouter',

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -105,13 +105,15 @@ const GoogleProviderSchema = z.object({
 	apiKey: z.string().catch(''),
 	baseUrl: z.string().catch(''),
 	useCustomUrl: z.boolean().catch(false),
-	models: z.array(z.string()).catch([])
+	models: z.array(z.string()).catch([]),
+	embeddingDimensions: z.number().min(1).catch(768)
 }).catch({
 	name: 'Google',
 	apiKey: '',
 	baseUrl: '',
 	useCustomUrl: false,
-	models: []
+	models: [],
+	embeddingDimensions: 768
 })
 
 const OpenAIProviderSchema = z.object({
@@ -133,13 +135,15 @@ const OpenAICompatibleProviderSchema = z.object({
 	apiKey: z.string().catch(''),
 	baseUrl: z.string().optional(),
 	useCustomUrl: z.boolean().catch(true),
-	models: z.array(z.string()).catch([])
+	models: z.array(z.string()).catch([]),
+	embeddingDimensions: z.number().min(1).catch(768)
 }).catch({
 	name: 'OpenAICompatible',
 	apiKey: '',
 	baseUrl: '',
 	useCustomUrl: true,
-	models: []
+	models: [],
+	embeddingDimensions: 768
 })
 
 const OllamaProviderSchema = z.object({
@@ -147,13 +151,15 @@ const OllamaProviderSchema = z.object({
 	apiKey: z.string().catch('ollama'),
 	baseUrl: z.string().catch(''),
 	useCustomUrl: z.boolean().catch(false),
-	models: z.array(z.string()).catch([])
+	models: z.array(z.string()).catch([]),
+	embeddingDimensions: z.number().min(1).catch(768)
 }).catch({
 	name: 'Ollama',
 	apiKey: 'ollama',
 	baseUrl: '',
 	useCustomUrl: true,
-	models: []
+	models: [],
+	embeddingDimensions: 768
 })
 
 const GroqProviderSchema = z.object({


### PR DESCRIPTION
## Description

1. google provider传入baseurl无效，而且模型列表是硬编码，现google provider修复了baseUrl无效的问题
2. 模型列表也接口获取，嵌入模型增加了手动输入dimension
<img width="795" height="436" alt="2025-08-26_14-39-03" src="https://github.com/user-attachments/assets/f79f23ff-b0d8-4c96-99d0-5094e2949304" />


## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have run the test suite (by running `pnpm run test`)
- [x] I have tested the functionality manually
