### PR TITLE
Update default Gemini model IDs

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -270,9 +270,9 @@ async function fetchOpenRouterModels(): Promise<Record<string, ModelInfo>> {
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-2.5-pro-preview-05-06"
-export const geminiDefaultInsightModelId: GeminiModelId = "gemini-2.5-flash-preview-05-20"
-export const geminiDefaultAutoCompleteModelId: GeminiModelId = "gemini-2.5-flash-preview-05-20"
+export const geminiDefaultModelId: GeminiModelId = "gemini-2.5-pro"
+export const geminiDefaultInsightModelId: GeminiModelId = "gemini-2.5-flash"
+export const geminiDefaultAutoCompleteModelId: GeminiModelId = "gemini-2.5-flash"
 export const geminiDefaultEmbeddingModelId: keyof typeof geminiEmbeddingModels = "text-embedding-004"
 
 export const geminiModels = {


### PR DESCRIPTION
## Description

Since Gemini already remove model `gemini-2.5-pro-preview-05-06`, and `gemini-2.5-flash-preview-05-20`, if we use as default model to test connection, it will failed with 404 error, so update model to `gemini-2.5-pro` and `gemini-2.5-flash`.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have run the test suite (by running `pnpm run test`)
- [x] I have tested the functionality manually
